### PR TITLE
Calendar View for Expenses

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize|stateHidden"/>
 
+        <activity android:name=".expensehistory.presentation.ExpenseHistoryActivity"
+            android:screenOrientation="portrait"/>
+
         <activity android:name=".settings.presentation.SettingsActivity"
             android:screenOrientation="portrait"/>
 

--- a/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseFragmentModel.kt
+++ b/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseFragmentModel.kt
@@ -1,0 +1,100 @@
+package com.nominalista.expenses.expensehistory.presentation
+
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.nominalista.expenses.Application
+import com.nominalista.expenses.data.model.Expense
+import com.nominalista.expenses.data.model.Tag
+import com.nominalista.expenses.data.store.DataStore
+import com.nominalista.expenses.home.domain.FilterExpensesUseCase
+import com.nominalista.expenses.home.domain.SortExpensesUseCase
+import com.nominalista.expenses.home.presentation.ExpenseItemModel
+import com.nominalista.expenses.util.extensions.plusAssign
+import com.nominalista.expenses.util.reactive.DataEvent
+import com.nominalista.expenses.util.reactive.Variable
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers.computation
+import io.reactivex.schedulers.Schedulers.io
+import org.threeten.bp.LocalDate
+
+class ExpenseFragmentModel(
+        application: Application,
+        private val dataStore: DataStore
+) : AndroidViewModel(application) {
+
+    val expenseItemModels = Variable(emptyList<ExpenseItemModel>())
+    val isLoading = Variable(false)
+    val showExpenseDetail = DataEvent<Expense>()
+
+    var expenses = emptyList<Expense>()
+    var tags = emptyList<Tag>()
+
+    private val disposables = CompositeDisposable()
+
+    // Lifecycle start
+
+    init {
+        observeExpenses()
+        updateExpenseItemModels(LocalDate.now())
+    }
+
+
+    private fun observeExpenses() {
+        disposables += dataStore.observeExpenses()
+                .map { SortExpensesUseCase().invoke(it) }
+                .subscribeOn(io())
+                .observeOn(mainThread())
+                .subscribe { expenses = it; updateExpenseItemModels(LocalDate.now()) }
+    }
+
+    private fun updateExpenseItemModels(date: LocalDate) {
+        disposables += Observable.just(expenses)
+                .map { FilterExpensesUseCase().invoke(it, date) }
+                .map { createExpenseSection(it) }
+                .subscribeOn(computation())
+                .observeOn(mainThread())
+                .subscribe { expenseItemModels.value = it }
+    }
+
+    private fun createExpenseSection(expenses: List<Expense>): List<ExpenseItemModel> {
+        return expenses.map { expense -> createExpenseItemModel(expense) }
+    }
+
+    private fun createExpenseItemModel(expense: Expense): ExpenseItemModel {
+        val itemModel = ExpenseItemModel(expense)
+        itemModel.click = { showExpenseDetail.next(expense) }
+        return itemModel
+    }
+
+    // Lifecycle end
+
+    override fun onCleared() {
+        super.onCleared()
+        disposables.clear()
+    }
+
+    // Public
+
+    fun showExpensesForTheDay(date: LocalDate) {
+        disposables += Observable.just(expenses)
+                .map { FilterExpensesUseCase().invoke(it, date) }
+                .map { createExpenseSection(it) }
+                .subscribeOn(computation())
+                .observeOn(mainThread())
+                .subscribe { expenseItemModels.value = it }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    class Factory(private val application: Application) : ViewModelProvider.NewInstanceFactory() {
+
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            return ExpenseFragmentModel(
+                    application,
+                    application.defaultDataStore
+            ) as T
+        }
+    }
+}

--- a/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryActivity.kt
+++ b/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryActivity.kt
@@ -1,4 +1,5 @@
 package com.nominalista.expenses.expensehistory.presentation
+
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryActivity.kt
+++ b/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryActivity.kt
@@ -1,0 +1,25 @@
+package com.nominalista.expenses.expensehistory.presentation
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import com.nominalista.expenses.R
+import com.nominalista.expenses.common.presentation.BaseActivity
+
+class ExpenseHistoryActivity : BaseActivity() {
+
+    override var animationKind = ANIMATION_SLIDE_FROM_RIGHT
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_expense_history)
+        setSupportActionBar(findViewById(R.id.toolbar))
+    }
+
+    companion object {
+
+        fun start(context: Context) {
+            val intent = Intent(context, ExpenseHistoryActivity::class.java)
+            context.startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryAdapter.kt
+++ b/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryAdapter.kt
@@ -1,0 +1,74 @@
+package com.nominalista.expenses.expensehistory.presentation
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.nominalista.expenses.R
+import com.nominalista.expenses.home.presentation.ExpenseItemHolder
+import com.nominalista.expenses.home.presentation.ExpenseItemModel
+import com.nominalista.expenses.home.presentation.HomeItemHolder
+import com.nominalista.expenses.home.presentation.HomeItemModel
+
+class ExpenseHistoryAdapter : ListAdapter<HomeItemModel, HomeItemHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ExpenseItemHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val itemView = inflater.inflate(viewType, parent, false)
+        return when (viewType) {
+            EXPENSE_ITEM_TYPE -> ExpenseItemHolder(itemView)
+            else -> throw IllegalArgumentException()
+        }
+    }
+
+    override fun onBindViewHolder(holder: HomeItemHolder, position: Int) {
+        val itemModel = getItem(position)
+        when {
+            (holder is ExpenseItemHolder && itemModel is ExpenseItemModel) -> holder.bind(itemModel)
+        }
+    }
+
+    override fun onViewRecycled(holder: HomeItemHolder) {
+        super.onViewRecycled(holder)
+        when (holder) {
+            is ExpenseItemHolder -> holder.recycle()
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is ExpenseItemModel -> EXPENSE_ITEM_TYPE
+            else -> super.getItemViewType(position)
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<HomeItemModel>() {
+
+        override fun areItemsTheSame(
+                oldItem: HomeItemModel,
+                newItem: HomeItemModel
+        ): Boolean {
+            return when {
+                (oldItem is ExpenseItemModel && newItem is ExpenseItemModel) ->
+                    oldItem.expense.id == newItem.expense.id
+                else -> false
+            }
+        }
+
+        override fun areContentsTheSame(
+                oldItem: HomeItemModel,
+                newItem: HomeItemModel
+        ): Boolean {
+            return when {
+                (oldItem is ExpenseItemModel && newItem is ExpenseItemModel) ->
+                    oldItem.expense == newItem.expense
+                else -> false
+            }
+        }
+    }
+
+    companion object {
+
+        private const val EXPENSE_ITEM_TYPE = R.layout.item_expense
+    }
+}

--- a/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryFragment.kt
+++ b/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryFragment.kt
@@ -5,23 +5,79 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.CalendarView
+import android.widget.ProgressBar
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.nominalista.expenses.R
+import com.nominalista.expenses.data.model.Expense
+import com.nominalista.expenses.expensedetail.presentation.ExpenseDetailActivity
+import com.nominalista.expenses.util.extensions.application
+import com.nominalista.expenses.util.extensions.plusAssign
+import io.reactivex.disposables.CompositeDisposable
+import org.threeten.bp.LocalDate
 
-class ExpenseHistoryFragment : Fragment() {
+class ExpenseHistoryFragment : Fragment(), CalendarView.OnDateChangeListener {
+
+    private val compositeDisposable = CompositeDisposable()
+    private lateinit var expenseRecyclerView: RecyclerView
+    private lateinit var historyCalenderView: CalendarView
+    private lateinit var progressBar: ProgressBar
+
+    private lateinit var adapter: ExpenseHistoryAdapter
+    private lateinit var layoutManager: LinearLayoutManager
+    private lateinit var model: ExpenseFragmentModel
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
-        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_expense_history, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        bindWidgets(view)
         setupActionBar()
+        setupCalendarView()
+        setupRecyclerView()
+        setupViewModel()
+        bindModel()
     }
 
+    private fun bindWidgets(view: View) {
+        expenseRecyclerView = view.findViewById(R.id.rvExpenseHistory)
+        historyCalenderView = view.findViewById(R.id.cvExpenseHistory)
+        progressBar = view.findViewById(R.id.progress_bar)
+    }
+
+    private fun setupViewModel() {
+        val factory = ExpenseFragmentModel.Factory(requireContext().application)
+        model = ViewModelProviders.of(this, factory).get(ExpenseFragmentModel::class.java)
+    }
+
+    private fun setupCalendarView() {
+        historyCalenderView.setOnDateChangeListener(this)
+    }
+
+    private fun setupRecyclerView() {
+        adapter = ExpenseHistoryAdapter()
+        layoutManager = LinearLayoutManager(context)
+        expenseRecyclerView.adapter = adapter
+        expenseRecyclerView.layoutManager = layoutManager
+    }
+
+    private fun bindModel() {
+        compositeDisposable += model.expenseItemModels
+                .subscribe { adapter.submitList(it) }
+        compositeDisposable += model.isLoading
+                .subscribe { configureProgressBar(it) }
+        compositeDisposable += model.showExpenseDetail
+                .subscribe { showExpenseDetail(it) }
+    }
 
     private fun setupActionBar() {
         val actionBar = (requireActivity() as AppCompatActivity).supportActionBar ?: return
@@ -41,5 +97,27 @@ class ExpenseHistoryFragment : Fragment() {
     private fun backSelected(): Boolean {
         requireActivity().onBackPressed()
         return true
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        unbindFromModel()
+    }
+
+    private fun unbindFromModel() {
+        compositeDisposable.clear()
+    }
+
+    private fun configureProgressBar(isVisible: Boolean) {
+        progressBar.isVisible = isVisible
+    }
+
+    private fun showExpenseDetail(expense: Expense) {
+        ExpenseDetailActivity.start(requireContext(), expense)
+    }
+
+    override fun onSelectedDayChange(view: CalendarView, year: Int, month: Int, dayOfMonth: Int) {
+        Toast.makeText(activity, "Selected date is $dayOfMonth", Toast.LENGTH_SHORT).show()
+        model.showExpensesForTheDay(LocalDate.of(year, month + 1, dayOfMonth))
     }
 }

--- a/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryFragment.kt
+++ b/app/src/main/java/com/nominalista/expenses/expensehistory/presentation/ExpenseHistoryFragment.kt
@@ -1,0 +1,45 @@
+package com.nominalista.expenses.expensehistory.presentation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.nominalista.expenses.R
+
+class ExpenseHistoryFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_expense_history, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupActionBar()
+    }
+
+
+    private fun setupActionBar() {
+        val actionBar = (requireActivity() as AppCompatActivity).supportActionBar ?: return
+        actionBar.setTitle(R.string.expense_history_title)
+        actionBar.setDisplayHomeAsUpEnabled(true)
+        actionBar.setHomeAsUpIndicator(R.drawable.ic_arrow_back_24dp)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> backSelected()
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun backSelected(): Boolean {
+        requireActivity().onBackPressed()
+        return true
+    }
+}

--- a/app/src/main/java/com/nominalista/expenses/home/domain/FilterExpensesUseCase.kt
+++ b/app/src/main/java/com/nominalista/expenses/home/domain/FilterExpensesUseCase.kt
@@ -3,6 +3,7 @@ package com.nominalista.expenses.home.domain
 import com.nominalista.expenses.data.model.Expense
 import com.nominalista.expenses.home.presentation.DateRange
 import com.nominalista.expenses.home.presentation.TagFilter
+import org.threeten.bp.LocalDate
 
 class FilterExpensesUseCase {
 
@@ -14,6 +15,15 @@ class FilterExpensesUseCase {
         return expenses.filter { expense ->
             dateRange.contains(expense.date) &&
                     tagFilter?.let { expense.tags.containsAll(it.tags) } ?: true
+        }
+    }
+
+    operator fun invoke(
+            expenses: List<Expense>,
+            date: LocalDate
+    ): List<Expense> {
+        return expenses.filter { expense ->
+            expense.date == date
         }
     }
 }

--- a/app/src/main/java/com/nominalista/expenses/home/presentation/HomeActivity.kt
+++ b/app/src/main/java/com/nominalista/expenses/home/presentation/HomeActivity.kt
@@ -19,6 +19,7 @@ import com.nominalista.expenses.common.presentation.BaseActivity
 import com.nominalista.expenses.onboarding.OnboardingActivity
 import com.nominalista.expenses.settings.presentation.SettingsActivity
 import com.nominalista.expenses.about.AboutActivity
+import com.nominalista.expenses.expensehistory.presentation.ExpenseHistoryActivity
 import com.nominalista.expenses.util.extensions.application
 import com.nominalista.expenses.util.extensions.plusAssign
 import com.nominalista.expenses.util.extensions.startActivitySafely
@@ -70,6 +71,9 @@ class HomeActivity : BaseActivity() {
         exportExpensesItemLayout.setOnClickListener {
             runAfterDrawerClose { model.exportExpensesRequested() }
         }
+        expenseHistoryItemLayout.setOnClickListener {
+            runAfterDrawerClose { model.navigateToExpensesHistory() }
+        }
         settingsItemLayout.setOnClickListener {
             runAfterDrawerClose { model.navigateToSettingsRequested() }
         }
@@ -113,6 +117,8 @@ class HomeActivity : BaseActivity() {
             .subscribe { requestExportPermissions() }
         compositeDisposable += model.showExpenseExportFailureDialog
             .subscribe { showExpenseExportFailureDialog() }
+        compositeDisposable += model.navigateToExpensesHistory
+                .subscribe { navigateToExpenseHistory() }
         compositeDisposable += model.navigateToSettings
             .subscribe { navigateToSettings() }
         compositeDisposable += model.navigateToSupport
@@ -198,6 +204,10 @@ class HomeActivity : BaseActivity() {
 
     private fun navigateToSettings() {
         SettingsActivity.start(this)
+    }
+
+    private fun navigateToExpenseHistory() {
+        ExpenseHistoryActivity.start(this)
     }
 
     private fun navigateToSupport() {

--- a/app/src/main/java/com/nominalista/expenses/home/presentation/HomeActivityModel.kt
+++ b/app/src/main/java/com/nominalista/expenses/home/presentation/HomeActivityModel.kt
@@ -48,6 +48,7 @@ class HomeActivityModel(
     val requestExportPermissions = Event()
     val showExpenseExportFailureDialog = Event()
     val navigateToSettings = Event()
+    val navigateToExpensesHistory = Event()
     val navigateToSupport = Event()
 
     val showMessage = DataEvent<Int>()
@@ -122,6 +123,10 @@ class HomeActivityModel(
             }
             else -> return
         }
+    }
+
+    fun navigateToExpensesHistory() {
+        navigateToExpensesHistory.next()
     }
 
     fun navigateToSettingsRequested() {

--- a/app/src/main/java/com/nominalista/expenses/home/presentation/HomeFragmentModel.kt
+++ b/app/src/main/java/com/nominalista/expenses/home/presentation/HomeFragmentModel.kt
@@ -29,6 +29,7 @@ class HomeFragmentModel(
 ) : AndroidViewModel(application) {
 
     val itemModels = Variable(emptyList<HomeItemModel>())
+//    val expenseItemModels = Variable(emptyList<ExpenseItemModel>())
     val isLoading = Variable(false)
     val showExpenseDetail = DataEvent<Expense>()
     val showTagFiltering = Event()
@@ -50,6 +51,8 @@ class HomeFragmentModel(
         observeExpenses()
         observeTags()
         updateItemModels()
+//        observeExpensesItems()
+//        updateExpenseItemModels(LocalDate.now())
     }
 
     private fun setDateRange() {
@@ -82,6 +85,23 @@ class HomeFragmentModel(
             .observeOn(mainThread())
             .subscribe { itemModels.value = it }
     }
+
+  /*  private fun observeExpensesItems() {
+        disposables += dataStore.observeExpenses()
+                .map { SortExpensesUseCase().invoke(it) }
+                .subscribeOn(io())
+                .observeOn(mainThread())
+                .subscribe { expenses = it; updateExpenseItemModels(LocalDate.now()) }
+    }
+
+    private fun updateExpenseItemModels(date: LocalDate) {
+        disposables += Observable.just(expenses)
+                .map { FilterExpensesUseCase().invoke(it, date) }
+                .map { createExpenseSection(it) }
+                .subscribeOn(computation())
+                .observeOn(mainThread())
+                .subscribe { expenseItemModels.value = it }
+    }*/
 
     private fun createSummarySection(expenses: List<Expense>): List<HomeItemModel> {
         val summarySection = ArrayList<HomeItemModel>()
@@ -149,6 +169,15 @@ class HomeFragmentModel(
         this.tagFilter = tagFilter
         updateItemModels()
     }
+
+  /*  fun showExpensesForTheDay(date: LocalDate){
+        disposables += Observable.just(expenses)
+                .map { FilterExpensesUseCase().invoke(it, date) }
+                .map { createExpenseSection(it) }
+                .subscribeOn(computation())
+                .observeOn(mainThread())
+                .subscribe { expenseItemModels.value = it }
+    }*/
 
     fun deleteAllExpensesRequested() {
         showDeleteAllExpensesConfirmation.next()

--- a/app/src/main/res/drawable/ic_attach_money_24px.xml
+++ b/app/src/main/res/drawable/ic_attach_money_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11.8,10.9c-2.27,-0.59 -3,-1.2 -3,-2.15 0,-1.09 1.01,-1.85 2.7,-1.85 1.78,0 2.44,0.85 2.5,2.1h2.21c-0.07,-1.72 -1.12,-3.3 -3.21,-3.81V3h-3v2.16c-1.94,0.42 -3.5,1.68 -3.5,3.61 0,2.31 1.91,3.46 4.7,4.13 2.5,0.6 3,1.48 3,2.41 0,0.69 -0.49,1.79 -2.7,1.79 -2.06,0 -2.87,-0.92 -2.98,-2.1h-2.2c0.12,2.19 1.76,3.42 3.68,3.83V21h3v-2.15c1.95,-0.37 3.5,-1.5 3.5,-3.55 0,-2.84 -2.43,-3.81 -4.7,-4.4z" />
+</vector>

--- a/app/src/main/res/layout/activity_expense_history.xml
+++ b/app/src/main/res/layout/activity_expense_history.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:colorBackground"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?colorPrimary"
+        android:elevation="@dimen/spacing_normal"
+        android:theme="@style/ThemeOverlay.Expenses.Toolbar"
+        app:popupTheme="@style/ThemeOverlay.MaterialComponents.Light" />
+
+    <fragment
+        android:id="@+id/fragment_navigation_host"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/navigation_expense_history" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_expense_history.xml
+++ b/app/src/main/res/layout/fragment_expense_history.xml
@@ -8,11 +8,21 @@
     android:orientation="vertical"
     tools:context=".expensehistory.presentation.ExpenseHistoryFragment">
 
-    <TextView
+    <CalendarView
+        android:id="@+id/cvExpenseHistory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvExpenseHistory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="Hello"/>
-
+        android:layout_gravity="center" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_expense_history.xml
+++ b/app/src/main/res/layout/fragment_expense_history.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="vertical"
+    tools:context=".expensehistory.presentation.ExpenseHistoryFragment">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="Hello"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/include_drawer.xml
+++ b/app/src/main/res/layout/include_drawer.xml
@@ -135,7 +135,7 @@
             app:layout_constraintTop_toBottomOf="@id/exportExpensesItemLayout" />
 
         <LinearLayout
-            android:id="@+id/settingsItemLayout"
+            android:id="@+id/expenseHistoryItemLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -149,6 +149,43 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/sectionDivider">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:srcCompat="@drawable/ic_attach_money_24px"
+                app:tint="@color/color_on_surface_emphasis_medium" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/spacing_large"
+                android:drawablePadding="@dimen/spacing_normal"
+                android:fontFamily="sans-serif-medium"
+                android:text="@string/expense_history_title"
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:textColor="@color/color_on_surface_emphasis_medium"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/divider" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/settingsItemLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_normal"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="@dimen/spacing_xlarge"
+            android:paddingTop="@dimen/spacing_large"
+            android:paddingEnd="@dimen/spacing_xlarge"
+            android:paddingBottom="@dimen/spacing_large"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/expenseHistoryItemLayout">
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/navigation/navigation_expense_history.xml
+++ b/app/src/main/res/navigation/navigation_expense_history.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:startDestination="@id/fragment_expense_history">
+
+    <fragment
+        android:id="@+id/fragment_expense_history"
+        android:name="com.nominalista.expenses.expensehistory.presentation.ExpenseHistoryFragment"
+        android:label="ExpenseHistoryFragment" />
+
+</navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,4 +90,5 @@
     <string name="key_date_range" translatable="false">date_range</string>
     <string name="key_is_user_onboarded" translatable="false">is_user_onboarded</string>
     <string name="key_theme" translatable="false">theme</string>
+    <string name="expense_history_title">Expense History</string>
 </resources>


### PR DESCRIPTION
PR for Issue #7

Uses a simple android calendar view and uses existing framework to show the expenses in the calendar view. More info on the commits.

![splash-SplashActivity-02212020171401](https://user-images.githubusercontent.com/9157911/75080344-5b9aef80-54d1-11ea-9cf4-caec7b369603.png)

![splash-SplashActivity-02212020170239](https://user-images.githubusercontent.com/9157911/75080350-605fa380-54d1-11ea-9ec8-c52ca12bd3e8.png)

Adding events would require a bit more customization of calendar view or using any existing open source GitHub calendar view libraries with events support.